### PR TITLE
Add Matt_Phil_Elixir

### DIFF
--- a/Matt_Phil_Elixir/bank/.gitignore
+++ b/Matt_Phil_Elixir/bank/.gitignore
@@ -1,0 +1,4 @@
+/_build
+/deps
+erl_crash.dump
+*.ez

--- a/Matt_Phil_Elixir/bank/README.md
+++ b/Matt_Phil_Elixir/bank/README.md
@@ -1,0 +1,11 @@
+Bank
+====
+
+Leeds Code Dojo Bank Kata.
+
+We got up to parsing a line of characters.
+Learned a lot about string parsing in Elixir :)
+
+Run the tests with:
+
+mix test

--- a/Matt_Phil_Elixir/bank/config/config.exs
+++ b/Matt_Phil_Elixir/bank/config/config.exs
@@ -1,0 +1,24 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+use Mix.Config
+
+# This configuration is loaded before any dependency and is restricted
+# to this project. If another project depends on this project, this
+# file won't be loaded nor affect the parent project. For this reason,
+# if you want to provide default values for your application for third-
+# party users, it should be done in your mix.exs file.
+
+# Sample configuration:
+#
+#     config :logger, :console,
+#       level: :info,
+#       format: "$date $time [$level] $metadata$message\n",
+#       metadata: [:user_id]
+
+# It is also possible to import configuration files, relative to this
+# directory. For example, you can emulate configuration per environment
+# by uncommenting the line below and defining dev.exs, test.exs and such.
+# Configuration from the imported file will override the ones defined
+# here (which is why it is important to import them last).
+#
+#     import_config "#{Mix.env}.exs"

--- a/Matt_Phil_Elixir/bank/lib/bank.ex
+++ b/Matt_Phil_Elixir/bank/lib/bank.ex
@@ -1,0 +1,117 @@
+defmodule Bank do
+  require Logger
+
+  @doc ~S"""
+  Parse a line of characters
+
+  Example:
+
+      iex> str = """
+      iex>  _    
+      iex> | ||_|
+      iex> |_|  |
+      iex> """
+      " _  \n| ||_|\n|_|  |\n"
+      iex> Bank.line(str)
+      [0, 4]
+
+  """
+  def line(str) do
+    Enum.reverse(_line(String.split(str, "\n"), []))
+  end
+
+  # Last three chars, so return the last state (ie, all the parsed characters so far: [0,3,4])
+  defp _line([<< x1::utf8, x2::utf8, x3::utf8>>, << y1::utf8, y2::utf8, y3::utf8>>, << z1::utf8, z2::utf8, z3::utf8>>], state) do
+    [parse(to_string([x1, x2, x3, ?\n, y1, y2, y3, ?\n, z1, z2, z3, ?\n])) | state]
+  end
+  defp _line([<< x1::utf8, x2::utf8, x3::utf8, tail_one::binary>>, << y1::utf8, y2::utf8, y3::utf8, tail_two::binary>>, << z1::utf8, z2::utf8, z3::utf8, tail_three::binary>>], state) do
+    state_out = [parse(to_string([x1, x2, x3, ?\n, y1, y2, y3, ?\n, z1, z2, z3, ?\n])) | state]
+    
+    # We've got more characters, so carry on.
+    _line([tail_one, tail_two, tail_three], state_out)
+  end
+  # As a result of the String.split, we get an extra blank element at the end of the three lines.
+  defp _line([<< x1::utf8, x2::utf8, x3::utf8, tail_one::binary>>, << y1::utf8, y2::utf8, y3::utf8, tail_two::binary>>, << z1::utf8, z2::utf8, z3::utf8, tail_three::binary>>, _], state) do
+    state_out = [parse(to_string([x1, x2, x3, ?\n, y1, y2, y3, ?\n, z1, z2, z3, ?\n])) | state]
+    
+    # We've got more characters, so carry on.
+    _line([tail_one, tail_two, tail_three], state_out)
+  end
+    
+  @doc ~S"""
+  Parse a single digit.
+
+  Example:
+      iex> six = """
+      iex>  _ 
+      iex> |_
+      iex> |_|
+      iex> """
+      " _ \n|_\n|_|\n"
+      iex> Bank.parse(six)
+      6
+      iex> 
+
+  """
+  def parse("""
+             _ 
+            | |
+            |_|
+            """), do: 0
+
+
+  def parse("""
+               
+             |
+             |
+            """), do: 1
+
+  def parse("""
+             _ 
+             _|
+            |_
+            """), do: 2
+
+  def parse("""
+             _ 
+             _|
+             _|
+            """), do: 3
+
+  def parse("""
+               
+            |_|
+              |
+            """), do: 4
+
+  def parse("""
+             _ 
+            |_
+             _|
+            """), do: 5
+
+  def parse("""
+             _ 
+            |_
+            |_|
+            """), do: 6
+
+  def parse("""
+             _ 
+              |
+              |
+            """), do: 7
+
+  def parse("""
+             _ 
+            |_|
+            |_|
+            """), do: 8
+
+  def parse("""
+             _ 
+            |_|
+              |
+            """), do: 9
+
+end

--- a/Matt_Phil_Elixir/bank/mix.exs
+++ b/Matt_Phil_Elixir/bank/mix.exs
@@ -1,0 +1,30 @@
+defmodule Bank.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :bank,
+     version: "0.0.1",
+     elixir: "~> 1.0",
+     deps: deps]
+  end
+
+  # Configuration for the OTP application
+  #
+  # Type `mix help compile.app` for more information
+  def application do
+    [applications: [:logger]]
+  end
+
+  # Dependencies can be Hex packages:
+  #
+  #   {:mydep, "~> 0.3.0"}
+  #
+  # Or git/path repositories:
+  #
+  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
+  #
+  # Type `mix help deps` for more examples and options
+  defp deps do
+    []
+  end
+end

--- a/Matt_Phil_Elixir/bank/test/bank_test.exs
+++ b/Matt_Phil_Elixir/bank/test/bank_test.exs
@@ -1,0 +1,32 @@
+defmodule BankTest do
+  use ExUnit.Case
+
+  test "zero" do
+    str = """
+           _ 
+          | |
+          |_|
+          """
+    assert Bank.parse(str) == 0
+  end
+
+  test "zero four" do
+    str = """
+           _    
+          | ||_|
+          |_|  |
+          """
+
+    assert Bank.line(str) == [0,4]
+  end
+    
+  test "zero four seven nine" do
+    str = """
+           _     _  _ 
+          | ||_|  ||_|
+          |_|  |  |  |
+          """
+
+    assert Bank.line(str) == [0,4,7,9]
+  end
+end

--- a/Matt_Phil_Elixir/bank/test/test_helper.exs
+++ b/Matt_Phil_Elixir/bank/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
We got to user case 1 (while learning about multi-line pattern matching in Elixir).  Single digit matches weren't so bad.  I've now found out that you can match  the 'tail' of a binary string with
<<first_char::utf8, tail::binary>> = "abcd"
first_char == 32, tail == "bcd"

Thanks
